### PR TITLE
Update CSS links to be protocol agnostic

### DIFF
--- a/docs/_includes/solace-cloud-dependency.html
+++ b/docs/_includes/solace-cloud-dependency.html
@@ -5,12 +5,12 @@
 
 <!-- solace cloud header and footer css file-->
 <link rel="stylesheet" href="{{ "/css/solace-cloud-style.css" | prepend: site.baseurl }}">
-<link rel='stylesheet' id='avia-grid-css'  href='http://cloud.solace.com/wp-content/themes/enfold/css/grid.css?ver=2' type='text/css' media='all' />
-<link rel='stylesheet' id='avia-base-css'  href='http://cloud.solace.com/wp-content/themes/enfold/css/base.css?ver=2' type='text/css' media='all' />
-<link rel='stylesheet' id='avia-layout-css'  href='http://cloud.solace.com/wp-content/themes/enfold/css/layout.css?ver=2' type='text/css' media='all' />
-<link rel='stylesheet' id='avia-scs-css'  href='http://cloud.solace.com/wp-content/themes/enfold/css/shortcodes.css?ver=2' type='text/css' media='all' />
-<link rel='stylesheet' id='avia-dynamic-css'  href='http://cloud.solace.com/wp-content/uploads/dynamic_avia/enfold_child.css?ver=59f0fd6f5d3cd' type='text/css' media='all' />
-<script type='text/javascript' src='http://cloud.solace.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
-<script type='text/javascript' src='http://cloud.solace.com/wp-content/themes/enfold/js/avia.js?ver=3'></script>
-<script type='text/javascript' src='http://cloud.solace.com/wp-content/themes/enfold/js/shortcodes.js?ver=3'></script>
-<script type='text/javascript' src='http://cloud.solace.com/wp-content/themes/enfold/js/aviapopup/jquery.magnific-popup.min.js?ver=2'></script>
+<link rel='stylesheet' id='avia-grid-css'  href='//cloud.solace.com/wp-content/themes/enfold/css/grid.css?ver=2' type='text/css' media='all' />
+<link rel='stylesheet' id='avia-base-css'  href='//cloud.solace.com/wp-content/themes/enfold/css/base.css?ver=2' type='text/css' media='all' />
+<link rel='stylesheet' id='avia-layout-css'  href='//cloud.solace.com/wp-content/themes/enfold/css/layout.css?ver=2' type='text/css' media='all' />
+<link rel='stylesheet' id='avia-scs-css'  href='//cloud.solace.com/wp-content/themes/enfold/css/shortcodes.css?ver=2' type='text/css' media='all' />
+<link rel='stylesheet' id='avia-dynamic-css'  href='//cloud.solace.com/wp-content/uploads/dynamic_avia/enfold_child.css?ver=59f0fd6f5d3cd' type='text/css' media='all' />
+<script type='text/javascript' src='//cloud.solace.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='//cloud.solace.com/wp-content/themes/enfold/js/avia.js?ver=3'></script>
+<script type='text/javascript' src='//cloud.solace.com/wp-content/themes/enfold/js/shortcodes.js?ver=3'></script>
+<script type='text/javascript' src='//cloud.solace.com/wp-content/themes/enfold/js/aviapopup/jquery.magnific-popup.min.js?ver=2'></script>

--- a/docs/css/solace-cloud-style.css
+++ b/docs/css/solace-cloud-style.css
@@ -82,27 +82,27 @@ body#top {
 }
 
 @font-face {font-family: 'entypo-fontello'; font-weight: normal; font-style: normal;
-    src: url('http://cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.eot?v=3');
-    src: url('http://cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.eot?v=3#iefix') format('embedded-opentype'),
-    url('http://cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.woff?v=3') format('woff'),
-    url('http://cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.ttf?v=3') format('truetype'),
-    url('http://cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.svg?v=3#entypo-fontello') format('svg');
+    src: url('//cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.eot?v=3');
+    src: url('//cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.eot?v=3#iefix') format('embedded-opentype'),
+    url('//cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.woff?v=3') format('woff'),
+    url('//cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.ttf?v=3') format('truetype'),
+    url('//cloud.solace.com/wp-content/themes/enfold/config-templatebuilder/avia-template-builder/assets/fonts/entypo-fontello.svg?v=3#entypo-fontello') format('svg');
 } #top .avia-font-entypo-fontello, body .avia-font-entypo-fontello, html body [data-av_iconfont='entypo-fontello']:before{ font-family: 'entypo-fontello'; }
 
 @font-face {font-family: 'Flaticon'; font-weight: normal; font-style: normal;
-    src: url('http://cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.eot');
-    src: url('http://cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.eot?#iefix') format('embedded-opentype'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.woff') format('woff'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.ttf') format('truetype'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.svg#Flaticon') format('svg');
+    src: url('//cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.eot');
+    src: url('//cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.eot?#iefix') format('embedded-opentype'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.woff') format('woff'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.ttf') format('truetype'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/Flaticon/Flaticon.svg#Flaticon') format('svg');
 } #top .avia-font-Flaticon, body .avia-font-Flaticon, html body [data-av_iconfont='Flaticon']:before{ font-family: 'Flaticon'; }
 
 @font-face {font-family: 'flaticon'; font-weight: normal; font-style: normal;
-    src: url('http://cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.eot');
-    src: url('http://cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.eot?#iefix') format('embedded-opentype'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.woff') format('woff'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.ttf') format('truetype'),
-    url('http://cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.svg#flaticon') format('svg');
+    src: url('//cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.eot');
+    src: url('//cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.eot?#iefix') format('embedded-opentype'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.woff') format('woff'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.ttf') format('truetype'),
+    url('//cloud.solace.com/wp-content/uploads/avia_fonts/flaticon/flaticon.svg#flaticon') format('svg');
 } #top .avia-font-flaticon, body .avia-font-flaticon, html body [data-av_iconfont='flaticon']:before{ font-family: 'flaticon'; }
 
 /*******************************************************************************


### PR DESCRIPTION
Removing the HTTP allows the protocol to be selected based on the base page.