### PR TITLE
Arasmy/fix missing links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,18 @@ title: Solace Java API (JCSMP)
 summary: These tutorials get you up to speed sending and receiving messages with Solace technology.
 baseurl: "/solace-samples-java"
 repository: https://github.com/SolaceSamples/solace-samples-java
+
+# Also see _includes/intro.html to customize the description which gets included in index.html.
+
+# Link
+links-get-started: //dev.solace.com/get-started/java-tutorials/
+links-downloads: //dev.solace.com/downloads/
+links-community: //dev.solace.com/community/
+docs-core-concepts: //docs.solace.com/Features/Core-Concepts.htm
+docs-endpoints: //docs.solace.com/Features/Core-Concepts.htm#endpoints
+docs-api-ref: //docs.solace.com/API-Developer-Online-Ref-Documentation/java/index.html
+docs-gm-rr: //docs.solace.com/Solace-Messaging-APIs/Request-Reply-Messaging.htm
+docs-topic-queue: //docs.solace.com/Features/Core-Concepts.htm#topic-queue-mapping
+docs-client-profile: //docs.solace.com/Features/Core-Concepts.htm#client-profile
+links-solaceCloud-setup: //cloud.solace.com/create-messaging-service/
+docs-api-endpoints: //docs.solace.com/API-Developer-Online-Ref-Documentation/java/com/solacesystems/jcsmp/EndpointProperties.html


### PR DESCRIPTION
Fixed missing links on java samples
Pulled in latest version of jekyll template