### PR TITLE
Removed password argument requirement from basic samples.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Open a new GitHub pull request with the patch following the steps outlined below
 
 Before you submit your pull request consider the following guidelines:
 
-* Search [GitHub](https://github.com/SolaceSamples/solace-samples-template/pulls) for an open or closed Pull Request
+* Search [GitHub](https://github.com/SolaceSamples/solace-samples-java/pulls) for an open or closed Pull Request
   that relates to your submission. You don't want to duplicate effort.
 
 ### Submitting a Pull Request
@@ -29,11 +29,11 @@ Please follow these steps for all pull requests. These steps are derived from th
 
 #### Step 1: Fork
 
-Fork the project [on GitHub](https://github.com/SolaceSamples/solace-samples-template) and clone your fork
+Fork the project [on GitHub](https://github.com/SolaceSamples/solace-samples-java) and clone your fork
 locally.
 
 ```sh
-git clone https://github.com/<my-github-repo>/solace-samples-template
+git clone https://github.com/<my-github-repo>/solace-samples-java
 ```
 
 #### Step 2: Branch
@@ -67,7 +67,7 @@ $ git rebase upstream/master
 If you have not set the upstream, do so as follows:
 
 ```sh
-$ git remote add upstream https://github.com/SolaceSamples/solace-samples-template
+$ git remote add upstream https://github.com/SolaceSamples/solace-samples-java
 ```
 
 If you have already pushed your fork, then do not rebase. Instead merge any changes from master that are not already part of your branch.
@@ -82,7 +82,7 @@ git push origin my-fix-branch
 
 #### Step 6: Pull Request
 
-In GitHub, send a pull request to `solace-samples-template:master`.
+In GitHub, send a pull request to `solace-samples-java:master`.
 
 When fixing an existing issue, use the [commit message keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) to close the associated GitHub issue.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This tutorial requires the Solace Java API library. Download the Java API librar
 Just clone and build. For example:
 
   1. clone this GitHub repository
-  1. `./gradlew assemble`
+  2. `./gradlew assemble`
 
 ## Running the Samples
 

--- a/_docs/confirmed-delivery.md
+++ b/_docs/confirmed-delivery.md
@@ -72,8 +72,10 @@ First, connect to the Solace message router in exactly the same way as other tut
 final JCSMPProperties properties = new JCSMPProperties();
 properties.setProperty(JCSMPProperties.HOST, args[0]);
 properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]);
-properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
 properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]);
+if (args.length > 2) {
+    properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
+}
 final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
 session.connect();
 ```
@@ -184,7 +186,7 @@ This builds all of the Java Getting Started Samples with OS specific launch scri
 Run the example from the command line as follows.
 
 ```
-$ ./build/staged/bin/confirmedPublish <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/confirmedPublish <host:port> <client-username>@<message-vpn> [client-password]
 ```
 
 You have now successfully sent persistent messages to a Solace router and confirmed its receipt by correlating the acknowledgement.

--- a/_docs/persistence-with-queues.md
+++ b/_docs/persistence-with-queues.md
@@ -239,8 +239,8 @@ This builds all of the Java Getting Started Samples with OS specific launch scri
 First start the `QueueProducer` to send a message to the queue. Then you can use the `QueueConsumer` sample to receive the messages from the queue.
 
 ```
-$ ./build/staged/bin/queueProducer <host:port> <client-username>@<message-vpn> <client-password>
-$ ./build/staged/bin/queueConsumer <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/queueProducer <host:port> <client-username>@<message-vpn> [client-password]
+$ ./build/staged/bin/queueConsumer <host:port> <client-username>@<message-vpn> [client-password]
 ```
 
 You have now successfully connected a client, sent persistent messages to a queue and received them from a consumer flow.

--- a/_docs/publish-subscribe.md
+++ b/_docs/publish-subscribe.md
@@ -46,8 +46,10 @@ In the Solace messaging API for Java (JCSMP), Solace sessions are created from t
 final JCSMPProperties properties = new JCSMPProperties();
 properties.setProperty(JCSMPProperties.HOST, args[0]);
 properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]);
-properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
 properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]);
+if (args.length > 2) {
+    properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
+}
 final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
 
 session.connect();
@@ -186,7 +188,7 @@ This builds all of the Java Getting Started Samples with OS specific launch scri
 If you start the `TopicSubscriber`, with the required arguments of your Solace messaging, it will connect and wait for a message.
 
 ```
-$ ./build/staged/bin/topicSubscriber <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/topicSubscriber <host:port> <client-username>@<message-vpn> [client-password]
 TopicSubscriber initializing...
 Connected. Awaiting message...
 ```
@@ -194,7 +196,7 @@ Connected. Awaiting message...
 Then you can send a message using the `TopicPublisher` with the same arguments. If successful, the output for the producer will look like the following:
 
 ```
-$ ./build/staged/bin/topicPublisher <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/topicPublisher <host:port> <client-username>@<message-vpn> [client-password]
 Topic Publisher initializing...
 Connected. About to send message 'Hello world!' to topic 'tutorial/topic'...
 Message sent. Exiting.

--- a/_docs/request-reply.md
+++ b/_docs/request-reply.md
@@ -210,8 +210,8 @@ This builds all of the Java Getting Started Samples with OS specific launch scri
 First start the `BasicReplier` so that it is up and listening for requests. Then you can use the `BasicRequestor` sample to send requests and receive replies.
 
 ```
-$ ./build/staged/bin/basicReplier <host:port> <client-username>@<message-vpn> <client-password>
-$ ./build/staged/bin/basicRequestor <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/basicReplier <host:port> <client-username>@<message-vpn> [client-password]
+$ ./build/staged/bin/basicRequestor <host:port> <client-username>@<message-vpn> [client-password]
 ```
 
 With that you now know how to successfully implement the request-reply message exchange pattern using Direct messages.

--- a/_docs/topic-to-queue-mapping.md
+++ b/_docs/topic-to-queue-mapping.md
@@ -51,8 +51,10 @@ First, connect to the Solace message router in almost exactly the same way as ot
 final JCSMPProperties properties = new JCSMPProperties();
 properties.setProperty(JCSMPProperties.HOST, args[0]);
 properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]);
-properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
 properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]);
+if (args.length > 2) {
+    properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
+}
 // Make sure that the session is tolerant of the subscription<
 // already existing on the queue.
 properties.setProperty(JCSMPProperties.IGNORE_DUPLICATE_SUBSCRIPTION_ERROR, true);
@@ -161,7 +163,7 @@ This builds all of the Java Getting Started Samples with OS specific launch scri
 Run the example from the command line as follows.
 
 ```
-$ ./build/staged/bin/topicToQueueMapping <host:port> <client-username>@<message-vpn> <client-password>
+$ ./build/staged/bin/topicToQueueMapping <host:port> <client-username>@<message-vpn> [client-password]
 ```
 
 You have now added a topic subscription to a queue and successfully published persistent messages to the topic and had them arrive on your Queue endpoint.

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,11 @@ dependencies {
     compile("com.solacesystems:sol-jcsmp:10.2.0")
 }
 
-task createAllStartScripts() << {
+// unused, so commenting out (Issue #58)
+//task createAllStartScripts() << {
      // just a placeholder
-}
+//}
+
   def scripts = ['topicPublisher':'com.solace.samples.TopicPublisher',
 				 'topicSubscriber':'com.solace.samples.TopicSubscriber',
 				 'queueProducer':'com.solace.samples.QueueProducer',
@@ -79,7 +81,7 @@ task createAllStartScripts() << {
             fileMode = 0755
 			duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
-    createAllStartScripts.dependsOn(t)
+    //createAllStartScripts.dependsOn(t)
 }
 
 installDist {

--- a/src/main/java/com/solace/samples/BasicReplier.java
+++ b/src/main/java/com/solace/samples/BasicReplier.java
@@ -40,8 +40,10 @@ public class BasicReplier {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
         session.connect();
 
@@ -110,8 +112,8 @@ public class BasicReplier {
     public static void main(String... args) throws JCSMPException {
 
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: BasicReplier <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: BasicReplier <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }

--- a/src/main/java/com/solace/samples/BasicRequestor.java
+++ b/src/main/java/com/solace/samples/BasicRequestor.java
@@ -37,8 +37,8 @@ public class BasicRequestor {
 
     public static void main(String... args) throws JCSMPException {
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: BasicRequestor <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: BasicRequestor <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }
@@ -59,8 +59,10 @@ public class BasicRequestor {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session =  JCSMPFactory.onlyInstance().createSession(properties);
         session.connect();
 

--- a/src/main/java/com/solace/samples/ConfirmedPublish.java
+++ b/src/main/java/com/solace/samples/ConfirmedPublish.java
@@ -104,8 +104,10 @@ public class ConfirmedPublish {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
         session.connect();
 
@@ -158,8 +160,8 @@ public class ConfirmedPublish {
 
     public static void main(String... args) throws JCSMPException, InterruptedException {
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: ConfirmedPublish <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: ConfirmedPublish <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }

--- a/src/main/java/com/solace/samples/QueueConsumer.java
+++ b/src/main/java/com/solace/samples/QueueConsumer.java
@@ -37,8 +37,8 @@ public class QueueConsumer {
 
     public static void main(String... args) throws JCSMPException, InterruptedException {
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: QueueConsumer <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: QueueConsumer <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }
@@ -58,8 +58,10 @@ public class QueueConsumer {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
         session.connect();
 

--- a/src/main/java/com/solace/samples/QueueProducer.java
+++ b/src/main/java/com/solace/samples/QueueProducer.java
@@ -38,8 +38,8 @@ public class QueueProducer {
     public static void main(String... args) throws JCSMPException, InterruptedException {
 
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: QueueProducer <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: QueueProducer <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }
@@ -59,8 +59,10 @@ public class QueueProducer {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
 
         session.connect();

--- a/src/main/java/com/solace/samples/TopicPublisher.java
+++ b/src/main/java/com/solace/samples/TopicPublisher.java
@@ -33,8 +33,8 @@ public class TopicPublisher {
     public static void main(String... args) throws JCSMPException {
 
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: TopicPublisher <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: TopicPublisher <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }
@@ -55,8 +55,10 @@ public class TopicPublisher {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) { 
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final JCSMPSession session =  JCSMPFactory.onlyInstance().createSession(properties);
 
         session.connect();

--- a/src/main/java/com/solace/samples/TopicSubscriber.java
+++ b/src/main/java/com/solace/samples/TopicSubscriber.java
@@ -36,8 +36,8 @@ public class TopicSubscriber {
     public static void main(String... args) throws JCSMPException {
 
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: TopicSubscriber <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: TopicSubscriber <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }
@@ -56,8 +56,10 @@ public class TopicSubscriber {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         final Topic topic = JCSMPFactory.onlyInstance().createTopic("tutorial/topic");
         final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
 

--- a/src/main/java/com/solace/samples/TopicToQueueMapping.java
+++ b/src/main/java/com/solace/samples/TopicToQueueMapping.java
@@ -70,8 +70,10 @@ public class TopicToQueueMapping  {
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);     // host:port
         properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]); // client-username
-        properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
         properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]); // message-vpn
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]); // client-password
+        }
         
         // Make sure that the session is tolerant of the subscription already existing on the queue.
         properties.setProperty(JCSMPProperties.IGNORE_DUPLICATE_SUBSCRIPTION_ERROR, true);
@@ -161,8 +163,8 @@ public class TopicToQueueMapping  {
     public static void main(String... args) throws JCSMPException {
 
         // Check command line arguments
-        if (args.length != 3 || args[1].split("@").length != 2) {
-            System.out.println("Usage: TopicToQueueMapping <host:port> <client-username@message-vpn> <client-password>");
+        if (args.length < 2 || args[1].split("@").length != 2) {
+            System.out.println("Usage: TopicToQueueMapping <host:port> <client-username@message-vpn> [client-password]");
             System.out.println();
             System.exit(-1);
         }


### PR DESCRIPTION
Issue 54

Updated usage println to show optional [password] argument (using square brackets instead of angled ones).

Changed the args.length check to fail if less than 2, instead of not equal to 3.
